### PR TITLE
Implement saving game progress

### DIFF
--- a/locales/cs.json
+++ b/locales/cs.json
@@ -22,6 +22,9 @@
     "about": "O Hře",
     "language": "Jazyk"
   },
+  "dialog": {
+    "saveGameState": "Uložit pozici"
+  },
   "inputDialog": {
     "title": "Nová definice hry",
     "header": "Nová definice hry",

--- a/locales/en.json
+++ b/locales/en.json
@@ -22,6 +22,9 @@
     "about": "About Game",
     "language": "Language"
   },
+  "dialog": {
+    "saveGameState": "Save game state"
+  },
   "inputDialog": {
     "title": "New Game Definition",
     "header": "New Game Definition",

--- a/src/game_data.js
+++ b/src/game_data.js
@@ -431,6 +431,10 @@ class GameData {
         let end = this.getObjectById(gameEndId);
         return this.getDescription(end);
     }
+
+    toJSON() {
+        return JSON.stringify(this.#data, null, 2);
+    }
 }
 
 module.exports = GameData;

--- a/src/menu.js
+++ b/src/menu.js
@@ -97,6 +97,20 @@ function createMenu(currentLanguage, store, win) {
                 {
                     label: i18next.t('menu.saveGameState'),
                     accelerator: 'Ctrl+S'
+                    ,
+                    click: async () => {
+                        const { canceled, filePath } = await dialog.showSaveDialog(win, {
+                            title: i18next.t('dialog.saveGameState'),
+                            defaultPath: path.join(app.getPath('documents'), 'jeta_state.json'),
+                            filters: [{ name: 'JSON Files', extensions: ['json'] }]
+                        });
+                        if (!canceled && filePath) {
+                            const gameInstance = win.webContents.gameInstance;
+                            if (gameInstance && gameInstance.data && gameInstance.data.toJSON) {
+                                fs.writeFileSync(filePath, gameInstance.data.toJSON());
+                            }
+                        }
+                    }
                 },
                 {type: 'separator'},
                 {


### PR DESCRIPTION
## Summary
- add `toJSON()` helper to `GameData` to export current state
- enable `Save Game State` menu action to dump the running game as JSON
- add localization strings for the new dialog label

## Testing
- `npx jest`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6872158f6d848329baec0117a7bec247