### PR TITLE
Add live debug window

### DIFF
--- a/locales/cs.json
+++ b/locales/cs.json
@@ -20,7 +20,8 @@
     "reload": "Obnovit",
     "help": "Pomoc!",
     "about": "O Hře",
-    "language": "Jazyk"
+    "language": "Jazyk",
+    "debug": "Debug"
   },
   "dialog": {
     "saveGameState": "Uložit pozici"

--- a/locales/en.json
+++ b/locales/en.json
@@ -20,7 +20,8 @@
     "reload": "Reload",
     "help": "Help!",
     "about": "About Game",
-    "language": "Language"
+    "language": "Language",
+    "debug": "Debug"
   },
   "dialog": {
     "saveGameState": "Save game state"

--- a/resources/web/debug.html
+++ b/resources/web/debug.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Debug</title>
+  <style>
+    body { font-family: sans-serif; margin: 0; padding: 10px; }
+    textarea { width: 100%; height: calc(100vh - 50px); font-family: monospace; }
+    button { margin-top: 5px; }
+  </style>
+</head>
+<body>
+  <textarea id="json"></textarea>
+  <button id="save">Save</button>
+  <script>
+    const { ipcRenderer } = require('electron');
+    ipcRenderer.send('debug-request-state');
+    ipcRenderer.on('debug-state', (event, state) => {
+      document.getElementById('json').value = state;
+    });
+    document.getElementById('save').addEventListener('click', () => {
+      const text = document.getElementById('json').value;
+      ipcRenderer.send('debug-save-state', text);
+    });
+  </script>
+</body>
+</html>

--- a/src/debug_window.js
+++ b/src/debug_window.js
@@ -1,0 +1,57 @@
+const { BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+const GameData = require('./game_data');
+
+let debugWin = null;
+let mainWin = null;
+
+function createDebugWindow(parentWin) {
+    mainWin = parentWin;
+    if (debugWin) {
+        debugWin.focus();
+        return;
+    }
+    debugWin = new BrowserWindow({
+        width: 600,
+        height: 800,
+        webPreferences: {
+            nodeIntegration: true,
+            contextIsolation: false,
+            webSecurity: false
+        }
+    });
+
+    debugWin.loadFile(path.join(__dirname, '../resources/web/debug.html'));
+
+    debugWin.on('closed', () => {
+        debugWin = null;
+    });
+}
+
+function sendDebugState(gameEngine) {
+    if (debugWin) {
+        debugWin.webContents.send('debug-state', gameEngine.data.toJSON());
+    }
+}
+
+ipcMain.on('debug-request-state', (event) => {
+    if (mainWin && mainWin.webContents.gameInstance) {
+        event.sender.send('debug-state', mainWin.webContents.gameInstance.data.toJSON());
+    }
+});
+
+ipcMain.on('debug-save-state', (event, json) => {
+    if (!mainWin || !mainWin.webContents.gameInstance) return;
+    try {
+        const obj = JSON.parse(json);
+        const newData = new GameData(obj);
+        mainWin.webContents.gameInstance.data = newData;
+        mainWin.webContents.gameInstance.look();
+        mainWin.webContents.gameInstance.listCommands();
+        sendDebugState(mainWin.webContents.gameInstance);
+    } catch (e) {
+        console.error('Failed to update game state from debug window:', e);
+    }
+});
+
+module.exports = { createDebugWindow, sendDebugState };

--- a/src/game_engine.js
+++ b/src/game_engine.js
@@ -1,4 +1,5 @@
 const {ipcMain} = require('electron');
+const { sendDebugState } = require("./debug_window");
 
 ipcMain.on('game-action', (event, {action, param}) => {
     console.log(`Action received: ${action}, Parameter: ${param}`);
@@ -337,6 +338,7 @@ class GameEngine {
         if (this.win && this.win.webContents) {
             this.win.webContents.send('game-update', message, section);
             console.log("Message sent.");
+        sendDebugState(this);
         } else {
             console.error("Failed to send message: win or webContents is not defined.");
         }

--- a/src/menu.js
+++ b/src/menu.js
@@ -5,6 +5,7 @@ const i18next = require('./i18n');
 const {exec} = require('child_process');
 const {loadGameFile} = require('./game_definition_loader');
 const {play} = require('./game_engine');
+const { createDebugWindow } = require("./debug_window");
 
 
 
@@ -200,6 +201,12 @@ function createMenu(currentLanguage, store, win) {
                     click: () => {
                         console.log('Opening DevTools'); // Debugging line
                         win.webContents.openDevTools();
+                    }
+                },
+                {
+                    label: i18next.t('menu.debug'),
+                    click: () => {
+                        createDebugWindow(win);
                     }
                 },
                 {type: 'separator'},


### PR DESCRIPTION
## Summary
- add debug window showing current game state as JSON
- allow editing and saving JSON back into running game
- update debug window when game state changes
- include "Debug" menu option in English and Czech translations

## Testing
- `npm install`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68734e6e7b0c83299c65ddff4461038a