### PR TITLE
Implement encryption support

### DIFF
--- a/src/encryption.js
+++ b/src/encryption.js
@@ -1,0 +1,41 @@
+const crypto = require('crypto');
+
+const SECRET = 'jeta-secret-key';
+const ALGORITHM = 'aes-256-cbc';
+const KEY = crypto.scryptSync(SECRET, 'salt', 32);
+const IV = Buffer.alloc(16, 0); // static IV for simplicity
+
+function encryptData(data, method) {
+    if (method === 'aes') {
+        const cipher = crypto.createCipheriv(ALGORITHM, KEY, IV);
+        let encrypted = cipher.update(data, 'utf8', 'base64');
+        encrypted += cipher.final('base64');
+        return encrypted;
+    }
+    // default XOR obfuscation
+    const keyBuf = Buffer.from(SECRET);
+    const buffer = Buffer.from(data);
+    const out = Buffer.alloc(buffer.length);
+    for (let i = 0; i < buffer.length; i++) {
+        out[i] = buffer[i] ^ keyBuf[i % keyBuf.length];
+    }
+    return out.toString('base64');
+}
+
+function decryptData(data, method) {
+    if (method === 'aes') {
+        const decipher = crypto.createDecipheriv(ALGORITHM, KEY, IV);
+        let decrypted = decipher.update(data, 'base64', 'utf8');
+        decrypted += decipher.final('utf8');
+        return decrypted;
+    }
+    const keyBuf = Buffer.from(SECRET);
+    const buffer = Buffer.from(data, 'base64');
+    const out = Buffer.alloc(buffer.length);
+    for (let i = 0; i < buffer.length; i++) {
+        out[i] = buffer[i] ^ keyBuf[i % keyBuf.length];
+    }
+    return out.toString('utf8');
+}
+
+module.exports = { encryptData, decryptData };

--- a/src/game_definition_loader.js
+++ b/src/game_definition_loader.js
@@ -1,10 +1,12 @@
-const {dialog, ipcRenderer} = require('electron');
-const Ajv = require("ajv");
-const fs = require("fs");
-const yaml = require("js-yaml");
-const GameData = require("./game_data");
+const { dialog, ipcRenderer } = require('electron');
+const Ajv = require('ajv');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const GameData = require('./game_data');
 const { loadGameLayout } = require('./game_layout');
 const { updateGameDirectory } = require('./game_dir');
+const { decryptData } = require('./encryption');
 
 const schema = require("../resources/game_definition_schema.json");
 
@@ -15,21 +17,45 @@ const validate = ajv.compile(schema);
 
 async function loadGameFile(filePath, win) {
     try {
-        const fileData = fs.readFileSync(filePath, "utf-8");
-        console.log("File data read successfully.");
-        const inputData = yaml.load(fileData);
-        console.log("YAML data parsed successfully.");
+        let fileData = fs.readFileSync(filePath, 'utf-8');
+        console.log('File data read successfully.');
+
+        const ext = path.extname(filePath);
+        let method = 'yaml';
+
+        if (ext === '.enc' || ext === '.jenc') {
+            const idx = fileData.indexOf('\n');
+            if (idx !== -1) {
+                method = fileData.substring(0, idx).trim();
+                fileData = fileData.substring(idx + 1);
+            } else {
+                method = 'aes';
+            }
+            fileData = decryptData(fileData, method);
+        }
+
+        let inputData;
+        if (ext === '.json' || ext === '.jenc' || ext === '.enc') {
+            inputData = JSON.parse(fileData);
+        } else {
+            inputData = yaml.load(fileData);
+        }
+        console.log('Game data parsed successfully.');
 
         const valid = validate(inputData);
         if (!valid) {
-            console.error("Validation errors:", validate.errors);
-            // show modal window with error message
-            dialog.showErrorBox("Validation Error", JSON.stringify(validate.errors, null, 2));
+            console.error('Validation errors:', validate.errors);
+            dialog.showErrorBox('Validation Error', JSON.stringify(validate.errors, null, 2));
             return null;
         }
-        console.log("Game file is valid!");
+        console.log('Game file is valid!');
         const layoutLoaded = loadGameLayout(filePath, win);
         updateGameDirectory(filePath);
+        if (ext === '.enc' || ext === '.jenc') {
+            win.webContents.encryption = { method };
+        } else {
+            win.webContents.encryption = null;
+        }
         if (!layoutLoaded) {
             console.error('Chyba při načítání layoutu');
         }


### PR DESCRIPTION
## Summary
- add simple AES and XOR encryption helpers
- allow loading encrypted `.enc` or `.jenc` game files
- menu option to encrypt JSON game definitions
- disable debug and dev tools when encrypted files are loaded
- encrypt saved game state when encryption is active

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68735fd703d88329846d15892bcf108a