### PR TITLE
Support arithmetic expressions in parseSet

### DIFF
--- a/src/game_data.js
+++ b/src/game_data.js
@@ -328,18 +328,270 @@ class GameData {
         parts.forEach(cmd => {
             let trimmed = cmd.trim();
             if (!trimmed) return;
-            let [left, right] = trimmed.split('=');
-            if (!right) return;
+            let [left, ...rightParts] = trimmed.split('=');
+            if (!rightParts.length) return;
             left = left.trim();
-            right = right.trim();
+            let right = rightParts.join('=').trim();
 
+            const evaluation = this.evaluateSetExpression(right);
             let value;
-            if (right === 'true') value = true;
-            else if (right === 'false') value = false;
-            else value = right;
+            if (evaluation.usedExpression) {
+                value = evaluation.value;
+            } else if (right === 'true') {
+                value = true;
+            } else if (right === 'false') {
+                value = false;
+            } else {
+                value = right;
+            }
 
             this.setValue(left, value);
         });
+    }
+
+
+    evaluateSetExpression(expression) {
+        const tokens = this.tokenizeSetExpression(expression);
+        if (!tokens.length) {
+            return {usedExpression: false};
+        }
+
+        const containsExpression = tokens.some(token => token.type === 'operator' || token.type === 'paren');
+        if (!containsExpression) {
+            return {usedExpression: false};
+        }
+
+        const postfix = this.convertSetTokensToPostfix(tokens);
+        const value = this.evaluateSetPostfix(postfix);
+        return {usedExpression: true, value};
+    }
+
+
+    tokenizeSetExpression(expression) {
+        const tokens = [];
+        let i = 0;
+        const length = expression.length;
+
+        while (i < length) {
+            const ch = expression[i];
+
+            if (/\s/.test(ch)) {
+                i++;
+                continue;
+            }
+
+            if (ch === '"' || ch === '\'') {
+                const quote = ch;
+                i++;
+                let str = '';
+                while (i < length) {
+                    const current = expression[i];
+                    if (current === '\\' && i + 1 < length) {
+                        str += expression[i + 1];
+                        i += 2;
+                        continue;
+                    }
+                    if (current === quote) {
+                        i++;
+                        break;
+                    }
+                    str += current;
+                    i++;
+                }
+                tokens.push({type: 'string', value: str});
+                continue;
+            }
+
+            if (ch === '(' || ch === ')') {
+                tokens.push({type: 'paren', value: ch});
+                i++;
+                continue;
+            }
+
+            if (ch === '+' || ch === '*' || ch === '/' || ch === '%') {
+                tokens.push({type: 'operator', value: ch});
+                i++;
+                continue;
+            }
+
+            if (ch === '-') {
+                const prevToken = tokens.length ? tokens[tokens.length - 1] : null;
+                const isUnary = !prevToken || ((prevToken.type === 'operator') || (prevToken.type === 'paren' && prevToken.value === '('));
+                const nextChar = expression[i + 1];
+                if (isUnary && nextChar && /[0-9.]/.test(nextChar)) {
+                    let numStr = '-';
+                    i++;
+                    while (i < length && /[0-9.]/.test(expression[i])) {
+                        numStr += expression[i];
+                        i++;
+                    }
+                    tokens.push({type: 'number', value: parseFloat(numStr)});
+                    continue;
+                }
+                if (isUnary) {
+                    tokens.push({type: 'operator', value: 'NEG'});
+                    i++;
+                    continue;
+                }
+                tokens.push({type: 'operator', value: '-'});
+                i++;
+                continue;
+            }
+
+            if (/[0-9]/.test(ch)) {
+                let numStr = '';
+                while (i < length && /[0-9.]/.test(expression[i])) {
+                    numStr += expression[i];
+                    i++;
+                }
+                tokens.push({type: 'number', value: parseFloat(numStr)});
+                continue;
+            }
+
+            let start = i;
+            while (i < length) {
+                const current = expression[i];
+                if (/\s/.test(current) || current === '(' || current === ')' || current === '+' || current === '*' || current === '/' || current === '%' || current === '"' || current === '\'') {
+                    break;
+                }
+                if (current === '-' && i + 1 < length && /\d/.test(expression[i + 1])) {
+                    break;
+                }
+                i++;
+            }
+            const tokenStr = expression.slice(start, i);
+            if (!tokenStr) {
+                i++;
+                continue;
+            }
+            if (tokenStr === 'true' || tokenStr === 'false') {
+                tokens.push({type: 'boolean', value: tokenStr === 'true'});
+            } else {
+                tokens.push({type: 'identifier', value: tokenStr});
+            }
+        }
+
+        return tokens;
+    }
+
+
+    convertSetTokensToPostfix(tokens) {
+        const output = [];
+        const stack = [];
+        const precedence = {
+            'NEG': 3,
+            '*': 2,
+            '/': 2,
+            '%': 2,
+            '+': 1,
+            '-': 1
+        };
+
+        tokens.forEach(token => {
+            if (token.type === 'number' || token.type === 'string' || token.type === 'boolean' || token.type === 'identifier') {
+                output.push(token);
+            } else if (token.type === 'operator') {
+                while (stack.length) {
+                    const top = stack[stack.length - 1];
+                    if (top.type !== 'operator') break;
+                    const topPrec = precedence[top.value] ?? 0;
+                    const tokenPrec = precedence[token.value] ?? 0;
+                    const rightAssociative = token.value === 'NEG';
+                    if ((rightAssociative && tokenPrec < topPrec) || (!rightAssociative && tokenPrec <= topPrec)) {
+                        output.push(stack.pop());
+                    } else {
+                        break;
+                    }
+                }
+                stack.push(token);
+            } else if (token.type === 'paren') {
+                if (token.value === '(') {
+                    stack.push(token);
+                } else {
+                    while (stack.length && !(stack[stack.length - 1].type === 'paren' && stack[stack.length - 1].value === '(')) {
+                        output.push(stack.pop());
+                    }
+                    if (!stack.length) throw new Error('Nesouhlas závorek v set výrazu');
+                    stack.pop();
+                }
+            }
+        });
+
+        while (stack.length) {
+            const token = stack.pop();
+            if (token.type === 'paren') {
+                throw new Error('Nesouhlas závorek v set výrazu');
+            }
+            output.push(token);
+        }
+
+        return output;
+    }
+
+
+    evaluateSetPostfix(postfixTokens) {
+        const stack = [];
+        postfixTokens.forEach(token => {
+            if (token.type === 'number' || token.type === 'string' || token.type === 'boolean') {
+                stack.push(token.value);
+            } else if (token.type === 'identifier') {
+                stack.push(this.getValue(token.value));
+            } else if (token.type === 'operator') {
+                if (token.value === 'NEG') {
+                    if (!stack.length) throw new Error('Neplatný výraz v set příkazu');
+                    const value = stack.pop();
+                    stack.push(-this.toNumber(value));
+                } else {
+                    if (stack.length < 2) throw new Error('Neplatný výraz v set příkazu');
+                    const right = stack.pop();
+                    const left = stack.pop();
+                    stack.push(this.applyBinaryOperator(token.value, left, right));
+                }
+            }
+        });
+
+        if (stack.length !== 1) {
+            throw new Error('Neplatný výraz v set příkazu');
+        }
+        return stack[0];
+    }
+
+
+    applyBinaryOperator(operator, left, right) {
+        switch (operator) {
+            case '+':
+                if (typeof left === 'string' || typeof right === 'string') {
+                    return this.toStringValue(left) + this.toStringValue(right);
+                }
+                return this.toNumber(left) + this.toNumber(right);
+            case '-':
+                return this.toNumber(left) - this.toNumber(right);
+            case '*':
+                return this.toNumber(left) * this.toNumber(right);
+            case '/':
+                return this.toNumber(left) / this.toNumber(right);
+            case '%':
+                return this.toNumber(left) % this.toNumber(right);
+            default:
+                throw new Error(`Nepodporovaný operátor v set příkazu: ${operator}`);
+        }
+    }
+
+
+    toNumber(value) {
+        if (value === undefined || value === null || value === '') {
+            return 0;
+        }
+        const num = Number(value);
+        return Number.isNaN(num) ? 0 : num;
+    }
+
+
+    toStringValue(value) {
+        if (value === undefined || value === null) {
+            return '';
+        }
+        return String(value);
     }
 
 

--- a/src/test/condition-parser.test.js
+++ b/src/test/condition-parser.test.js
@@ -142,6 +142,19 @@ describe('GameData', () => {
         expect(gameData.parseCondition('plný_šálek')).toBe(true);
     });
 
+    test('parseSet supports arithmetic expressions', () => {
+        gameData.setValue('counter', 1);
+        gameData.parseSet('counter = counter + 1');
+        expect(gameData.getValue('counter')).toBe(2);
+
+        gameData.parseSet('counter = counter - 1');
+        expect(gameData.getValue('counter')).toBe(1);
+
+        gameData.setValue('šálek-čaje:onSee:count', 0);
+        gameData.parseSet('šálek-čaje:onSee:count = šálek-čaje:onSee:count + 1');
+        expect(gameData.getValue('šálek-čaje:onSee:count')).toBe(1);
+    });
+
     test('Set and avaluate onSee:count', () => {
         gameData.setValue('šálek-čaje:onSee:count', 0);
         var t = gameData.getValue('šálek-čaje:onSee:count');


### PR DESCRIPTION
## Summary
- enhance parseSet to evaluate arithmetic expressions when assigning values
- add expression parsing utilities to support math operations and string concatenation handling
- extend condition parser tests to cover arithmetic updates on variables and item counters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da44edf144832990c22930dd2b0b54