### PR TITLE
Add branching dialogue handling with selectable responses

### DIFF
--- a/resources/game_definition_schema.json
+++ b/resources/game_definition_schema.json
@@ -86,7 +86,34 @@
           "name": { "type": "string" },
           "name_accusative": { "type": "string" },
           "description": { "type": "string" },
-          "location": { "type": "string" }
+          "location": { "type": "string" },
+          "onTalk": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["description"],
+              "properties": {
+                "id": { "type": "string" },
+                "description": { "type": "string" },
+                "condition": { "type": "string" },
+                "set": { "type": "string" },
+                "responses": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["id", "text"],
+                    "properties": {
+                      "id": { "type": "string" },
+                      "text": { "type": "string" },
+                      "condition": { "type": "string" },
+                      "set": { "type": "string" },
+                      "next": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/samples/test/Test.yaml
+++ b/samples/test/Test.yaml
@@ -204,17 +204,33 @@ characters:
       - condition: "!dveře_otevřeny"
         description: "<p>Někdo je asi za dveřmi, ale nevím kdo. Možná by pomohlo otevřít dveře.</p>"
     onTalk:
-      - condition: "!dveře_otevřeny"
+      - id: "door_closed"
+        condition: "!dveře_otevřeny"
         description: "<p>Nemůžu mluvit s někým přes dveře to se přece nesluší na vychovaného mladého člověka.</p>"
-      - condition: "dveře_otevřeny"
-        description: "<p>Dobrý den pane co pro vás mohu udělat?!<br>
-         Dobrý den pane mám tu pro vás dopis od Ammm...Kamaráda Honzy. <br>
-         No ahá vy jste ten nový poštmistr co u nás měl od ledna nastoupit že? <br>
-         Nu dá se to tak brát, i když tu jsem jen na záskok ale díky za optání. <br> 
-         Není zač nashledanou! <br>
-         Nashledanou!<br>
-         Vrzz Cvak  Nu to jsem zvědav co v tom dopise vlasně je <br>
-         Trhh AHÁ to je Pozvánka pro vás na moji další hru!!!</p>"
+      - id: "door_greeting"
+        condition: "dveře_otevřeny"
+        description: "<p>Dobrý den pane co pro vás mohu udělat?</p>"
+        responses:
+          - id: "deliver_letter"
+            text: "Předat dopis"
+            next: "door_after_letter"
+          - id: "ask_job"
+            text: "Zeptat se na práci"
+            next: "door_job"
+          - id: "say_goodbye"
+            text: "Rozloučit se"
+            next: "door_farewell"
+      - id: "door_job"
+        description: "<p>Nu dá se to tak brát, i když tu jsem jen na záskok ale díky za optání.</p>"
+        responses:
+          - id: "job_back"
+            text: "Vrátit se k dopisu"
+            next: "door_greeting"
+      - id: "door_farewell"
+        description: "<p>Není zač, nashledanou!</p>"
+        set: "dveře_otevřeny = false"
+      - id: "door_after_letter"
+        description: "<p>Vrzz... Nu to jsem zvědav, co v tom dopise vlastně je. Trh! Ahá, to je pozvánka na moji další hru!</p>"
         set: "dveře_otevřeny = false; game_end = true; game_end_id=end_game_1"
 
 variables:

--- a/src/game_engine.js
+++ b/src/game_engine.js
@@ -11,6 +11,8 @@ ipcMain.on('game-action', (event, {action, param}) => {
 
     const game = event.sender.gameInstance;
 
+    let skipLook = false;
+
     switch (action) {
         case 'see':
             game.see(param);
@@ -33,10 +35,16 @@ ipcMain.on('game-action', (event, {action, param}) => {
         case 'talk':
             game.talk(param);
             break;
+        case 'dialog-choice':
+            skipLook = true;
+            game.handleDialogChoice(param);
+            break;
         default:
             console.error(`Unknown action: ${action}`);
     }
-    game.look();
+    if (!skipLook) {
+        game.look();
+    }
     if (!game.data.getValue("game_end", false)) {
         game.listCommands();
     } else {
@@ -54,6 +62,7 @@ class GameEngine {
         this.data = data;
         this.win = win;
         this.endGame = false;
+        this.activeDialogues = new Map();
     }
 
 
@@ -249,32 +258,174 @@ class GameEngine {
         }
     }
 
-    talk(characterName) {
-        // Najdu postavu
-        let ch = Object.values(this.data.characters).find(c => c.name.toLowerCase() === characterName.toLowerCase());
+    talk(characterIdentifier) {
+        const ch = this.findCharacter(characterIdentifier);
         if (!ch) {
             this.sendUpdate("Takovou postavu tu nevidím.");
             return;
         }
-        // onTalk
-        if (!ch.onTalk) {
+
+        if (!ch.onTalk || !ch.onTalk.length) {
             this.sendUpdate("Tahle postava nemá co říct.");
             return;
         }
-        let spoke = false;
-        for (let t of ch.onTalk) {
-            if (t.condition) {
-                if (!this.data.parseCondition(t.condition, this)) continue;
+
+        const activeEntryId = this.activeDialogues.get(ch.id);
+        if (activeEntryId) {
+            const activeEntry = this.data.getDialogueEntry(ch.id, activeEntryId);
+            if (activeEntry) {
+                const activeResult = this.presentDialogueEntry(ch, activeEntry);
+                if (activeResult.hasResponses) {
+                    return;
+                }
             }
-            this.sendUpdate(t.description);
-            if (t.set) {
-                this.data.parseSet(t.set, this);
-            }
-            spoke = true;
+            this.activeDialogues.delete(ch.id);
         }
+
+        let spoke = false;
+        for (let entry of ch.onTalk) {
+            if (entry.condition && !this.data.parseCondition(entry.condition)) {
+                continue;
+            }
+
+            const result = this.presentDialogueEntry(ch, entry);
+            if (result.spoke) {
+                spoke = true;
+            }
+
+            if (result.hasResponses) {
+                spoke = true;
+                return;
+            }
+        }
+
         if (!spoke) {
             this.sendUpdate("Nepodařilo se navázat rozhovor.");
         }
+    }
+
+    handleDialogChoice(payload) {
+        if (!payload || typeof payload !== 'object') {
+            this.sendUpdate("Tahle odpověď není dostupná.");
+            return;
+        }
+
+        const {characterId, choiceId, entryId} = payload;
+        const character = this.data.getCharacterById(characterId) || this.findCharacter(characterId);
+        if (!character) {
+            this.sendUpdate("Takovou postavu tu nevidím.");
+            return;
+        }
+
+        const currentEntryId = entryId || this.activeDialogues.get(character.id);
+        if (!currentEntryId) {
+            this.sendUpdate("Žádný rozhovor není aktivní.");
+            return;
+        }
+
+        const entry = this.data.getDialogueEntry(character.id, currentEntryId);
+        if (!entry || !entry.responses) {
+            this.activeDialogues.delete(character.id);
+            this.sendUpdate("Tahle replika není dostupná.");
+            return;
+        }
+
+        const response = entry.responses.find(r => r.id === choiceId);
+        if (!response) {
+            this.sendUpdate("Takovou odpověď nemáš.");
+            return;
+        }
+
+        if (response.condition && !this.data.parseCondition(response.condition)) {
+            this.sendUpdate("Tahle odpověď není dostupná.");
+            return;
+        }
+
+        if (response.text) {
+            this.sendUpdate(`<p class="dialogue-choice">${escapeHtml(response.text)}</p>`);
+        }
+
+        if (response.set) {
+            this.data.parseSet(response.set);
+        }
+
+        if (response.next) {
+            const nextEntry = this.data.getDialogueEntry(character.id, response.next);
+            if (nextEntry) {
+                const result = this.presentDialogueEntry(character, nextEntry);
+                if (!result.hasResponses) {
+                    this.activeDialogues.delete(character.id);
+                }
+                return;
+            }
+            this.sendUpdate("Chybí navazující replika v rozhovoru.");
+        }
+
+        this.activeDialogues.delete(character.id);
+    }
+
+    presentDialogueEntry(character, entry) {
+        if (entry.condition && !this.data.parseCondition(entry.condition)) {
+            this.activeDialogues.delete(character.id);
+            return {spoke: false, hasResponses: false};
+        }
+
+        let spoke = false;
+        if (entry.description) {
+            this.sendUpdate(entry.description);
+            spoke = true;
+        }
+
+        if (entry.set) {
+            this.data.parseSet(entry.set);
+            spoke = true;
+        }
+
+        let hasResponses = false;
+        if (entry.responses && entry.responses.length) {
+            if (!entry.id) {
+                this.activeDialogues.delete(character.id);
+            } else {
+                const options = this.data.getDialogueOptions(character.id, entry.id);
+                if (options.length) {
+                    const markup = this.renderDialogueOptions(character.id, entry.id, options);
+                    this.sendUpdate(markup);
+                    this.activeDialogues.set(character.id, entry.id);
+                    hasResponses = true;
+                    if (!spoke) {
+                        spoke = true;
+                    }
+                } else {
+                    this.activeDialogues.delete(character.id);
+                }
+            }
+        } else {
+            this.activeDialogues.delete(character.id);
+        }
+
+        return {spoke, hasResponses};
+    }
+
+    renderDialogueOptions(characterId, entryId, options) {
+        const encodedCharacter = encodeDataAttribute(characterId);
+        const encodedEntry = encodeDataAttribute(entryId);
+        const links = options.map(option => {
+            const encodedChoice = encodeDataAttribute(option.id);
+            return `<a href="#" class="game-action dialog-option" data-action="dialog-choice" data-character="${encodedCharacter}" data-entry="${encodedEntry}" data-choice="${encodedChoice}">${escapeHtml(option.text)}</a>`;
+        }).join(' | ');
+        return `<div class="dialogue-options" data-character="${encodedCharacter}" data-entry="${encodedEntry}">${links}</div>`;
+    }
+
+    findCharacter(identifier) {
+        if (!identifier) {
+            return null;
+        }
+        const value = identifier.toString().toLowerCase();
+        return Object.values(this.data.characters).find(c => {
+            const byId = (c.id || '').toLowerCase() === value;
+            const byName = (c.name || '').toLowerCase() === value;
+            return byId || byName;
+        }) || null;
     }
 
     listEndings() {
@@ -352,6 +503,26 @@ function getAccusativeName(entity) {
     return entity.name_accusative || entity.name || "";
 }
 
+function encodeDataAttribute(value) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+    return encodeURIComponent(value.toString());
+}
+
+function escapeHtml(value) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+    return value
+        .toString()
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 function createTalkHrefRow(charactersInLoc) {
     if (!charactersInLoc || charactersInLoc.length === 0) return "";
     let seeHrefRow = "";
@@ -361,7 +532,7 @@ function createTalkHrefRow(charactersInLoc) {
         if (seeHrefRow !== "") seeHrefRow += " | ";
         seeHrefRow += `<a href="#" class="game-action" data-action="see" data-param="${character.id}">${displayName}</a>`;
         if (talkHrefRow !== "") talkHrefRow += " | ";
-        talkHrefRow += `<a href="#" class="game-action" data-action="talk" data-param="${character.name}">${displayName}</a>`;
+        talkHrefRow += `<a href="#" class="game-action" data-action="talk" data-param="${character.id}">${displayName}</a>`;
     });
     return '<span>Prozkoumat:</span>' + seeHrefRow + '<br><span>Oslovit: </span>' + talkHrefRow;
 }


### PR DESCRIPTION
## Summary
- extend the game definition schema so character dialogues can define optional responses and link to follow-up lines
- validate and index dialogues in `GameData` while exposing helpers for fetching the available responses
- update the engine and renderer to show clickable dialogue options, process `dialog-choice` actions, and demonstrate the behaviour in the sample YAML

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd70b5a9008329b14ada9adafe63de